### PR TITLE
feat: migrate to Actix runtime and improve Bearer token handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror 2.0.12",
- "tokio",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ default = ["openssl"]
 openssl = ["reqwest/default-tls"]
 rustls = ["reqwest/rustls-tls"]
 
+[[example]]
+name = "server"
+path = "examples/server.rs"
+
 [dependencies]
 actix-web = "4"
 actix-web-httpauth = "0.8.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ reqwest = { version = "0.12.19", default-features = false, features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
-tokio = { version = "1.45.1", features = [] }
 tracing = "0.1.41"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -10,14 +10,6 @@ This crate lets you verify Firebase ID tokens in Actix Web apps. It’s built to
 
 ## Installation
 
-Manually add the crate to your `Cargo.toml`:
-
-```toml
-actix-firebase-auth = { version = "0.1.0" }
-```
-
-Using **cargo**:
-
 ```bash
 cargo add actix-firebase-auth
 ```
@@ -30,40 +22,20 @@ If verification fails - due to a missing token, expiration, or invalid signature
 
 ### Example
 
-#### Client-side
+See [/examples/server.rs](/examples/server.rs) for a minimal Actix Web server.
 
-A web client must send requests in the following format:
+To run this example:
 
-```http
-GET /whoami HTTP/1.1
-Host: api.example.com
-Authorization: Bearer <Firebase_ID_Token>
+```bash
+cargo run --example server
 ```
 
-#### Server-side
+Make sure to include a valid Firebase ID token in the `Authorization` header when calling protected endpoints:
 
-```rust
-use actix_web::{web, get, App, HttpServer, HttpResponse, Responder};
-use actix_firebase_auth::{FirebaseAuth, FirebaseUser};
-
-#[get("/whoami")]
-async fn whoami(user: FirebaseUser) -> HttpResponse {
-    HttpResponse::Ok().json(user)
-}
-
-#[actix_web::main]
-async fn main() -> std::io::Result<()> {
-    let auth = FirebaseAuth::new("your-project-id").await;
-
-    HttpServer::new(move || {
-        App::new()
-            .app_data(web::Data::new(auth.clone()))
-            .service(whoami)
-    })
-    .bind(("127.0.0.1", 8080))?
-    .run()
-    .await
-}
+```http
+GET /protected HTTP/1.1
+Host: api.example.com
+Authorization: Bearer <Firebase_ID_Token>
 ```
 
 ## Testing

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,0 +1,53 @@
+//! Minimal Actix Web example demonstrating [FirebaseUser] extractor.
+//!
+//! This server exposes two endpoints:
+//! - `/protected`: Requires a valid Firebase ID token and returns the decoded user info.
+//! - `/whoami`: Returns user info if authenticated, or `"Anonymous"` otherwise.
+//!
+//! Firebase project ID can be set via the `FIREBASE_PROJECT_ID` environment variable,
+//! otherwise it falls back to "your-project-id" for testing purposes.
+
+use actix_firebase_auth::{FirebaseAuth, FirebaseUser};
+use actix_web::{App, HttpResponse, HttpServer, Responder, get, web};
+use std::env;
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    // Read project ID from environment variable or fallback to a default for dev
+    let project_id =
+        env::var("FIREBASE_PROJECT_ID").unwrap_or_else(|_| "your-project-id".to_string());
+
+    // Initialize Firebase Auth client (fetches public keys etc.)
+    let auth = match FirebaseAuth::new(&project_id).await {
+        Ok(auth) => auth,
+        Err(e) => {
+            eprintln!("Failed to initialize FirebaseAuth: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    HttpServer::new(move || {
+        App::new()
+            .app_data(web::Data::new(auth.clone()))
+            .service(protected)
+            .service(whoami)
+    })
+    .bind(("127.0.0.1", 8080))?
+    .run()
+    .await
+}
+
+// Protected route — requires a valid Firebase ID token
+#[get("/protected")]
+async fn protected(user: FirebaseUser) -> impl Responder {
+    HttpResponse::Ok().json(user)
+}
+
+// Returns the authenticated user's info, or null if unauthenticated
+#[get("/whoami")]
+async fn whoami(user: Option<FirebaseUser>) -> impl Responder {
+    match user {
+        Some(u) => HttpResponse::Ok().json(u),
+        None => HttpResponse::Ok().body("Anonymous"),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! #[actix_web::main]
 //! async fn main() -> std::io::Result<()> {
-//!     let auth = FirebaseAuth::new("your-project-id").await;
+//!     let auth = FirebaseAuth::new("your-project-id").await.unwrap(); // Don't forget to handle this error
 //!
 //!     HttpServer::new(move || {
 //!         App::new()


### PR DESCRIPTION

## 📑 Description

**This PR includes the following changes**:

- updates the authentication extractor to return RFC 7235-compliant `401 Unauthorized` responses for invalid or missing Bearer tokens
- replaces the Tokio runtime with Actix Web
- adds a [minimal Actix Web server example](examples/server.rs).
