### PR TITLE
fix: correctly format full issuer URL

### DIFF
--- a/src/jwk/config.rs
+++ b/src/jwk/config.rs
@@ -1,17 +1,13 @@
-use std::{fmt, ops::Deref};
+use std::ops::Deref;
 
 #[derive(Debug, Clone)]
 pub struct Issuer(String);
 
 impl Issuer {
     pub fn new(project_id: impl AsRef<str>) -> Issuer {
-        Issuer(project_id.as_ref().to_owned())
-    }
-}
-
-impl fmt::Display for Issuer {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "https://securetoken.google.com/{}", &self.0)
+        let issuer =
+            format!("https://securetoken.google.com/{}", project_id.as_ref());
+        Issuer(issuer)
     }
 }
 


### PR DESCRIPTION
## 📑 Description

Previously, the `Issuer` type stored only the `project_id`, and the full issuer URL (`https://securetoken.google.com/{project_id}`) was only constructed in the `Display` implementation. This caused inconsistencies and potential bugs when `Issuer` was used directly (e.g., for string comparison or serialization).

Now, the full issuer URL is built and stored during `Issuer::new`.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple PRs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Add a brief description of the PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
