### PR TITLE
refactor: strongly type FirebaseUser fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 tracing = "0.1.41"
+url = { version = "2.5.4", default-features = false, features = ["serde"] }
 
 [dev-dependencies]
 actix-rt = "2.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ path = "examples/server.rs"
 actix-web = "4"
 actix-web-httpauth = "0.8.2"
 base64 = "0.22.1"
+email_address = "0.2.9"
 futures = "0.3"
 jsonwebtoken = "9.3.1"
 reqwest = { version = "0.12.19", default-features = false, features = ["json"] }

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,3 +1,4 @@
+use email_address::EmailAddress;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use url::Url;
@@ -39,7 +40,7 @@ pub struct FirebaseUser {
     pub picture: Option<Url>,
 
     /// User's email address
-    pub email: Option<String>,
+    pub email: Option<EmailAddress>,
 
     /// Whether the user's email has been verified
     pub email_verified: Option<bool>,

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use url::Url;
 
 /// Represents the decoded JWT claims from a Firebase Authentication token.
 ///
@@ -35,7 +36,7 @@ pub struct FirebaseUser {
     pub name: Option<String>,
 
     /// URL to the user's profile picture (if available)
-    pub picture: Option<String>,
+    pub picture: Option<Url>,
 
     /// User's email address
     pub email: Option<String>,


### PR DESCRIPTION
## 📑 Description
This PR refactors the `FirebaseUser` struct in order to improve type safety across the Firebase identity model, make misuse harder and enabling better IDE support and serialization guarantees.

### Changes
- Replaced `email` field type with `EmailAddress` for stricter validation and improved clarity.
- Updated `picture` field to use `Url` instead of `String` to ensure valid and parseable URLs.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
